### PR TITLE
Dependencies Upgrade As Of 2025-05-20

### DIFF
--- a/network-device-inventory-service/pom.xml
+++ b/network-device-inventory-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.4</version>
+		<version>3.4.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.lyess</groupId>


### PR DESCRIPTION
- org.springframework.boot:spring-boot upgrade to 3.4.5.
- org.springdoc:springdoc-openapi-starter-webmvc-ui upgrade to 2.8.8.